### PR TITLE
reduce write lock contention existing in play tasks, decouple ColorSp…

### DIFF
--- a/src/appui.rs
+++ b/src/appui.rs
@@ -30,7 +30,7 @@ use image::{DynamicImage, EncodableLayout, RgbaImage};
 use rodio::Player;
 use tokio::{
     runtime::{Handle, Runtime},
-    sync::RwLock,
+    sync::{Notify, RwLock},
 };
 use tracing::{info, warn};
 
@@ -83,7 +83,7 @@ pub struct AppUI {
     garbage_video_texture: Arc<RwLock<Option<TextureId>>>,
     tiny_decoder: Arc<RwLock<crate::decode::TinyDecoder>>,
     audio_player: crate::audio_play::AudioPlayer,
-    _present_data_manager: PresentDataManager,
+    _present_data_manager: Arc<RwLock<PresentDataManager>>,
     current_main_stream_timestamp: Arc<AtomicI64>,
     _main_color_image: Arc<RwLock<ColorImage>>,
     _bg_dyn_img: Arc<DynamicImage>,
@@ -256,12 +256,20 @@ impl AppUI {
             cc.egui_ctx.clone(),
             hardware_config_flag.clone(),
         )?));
+        let audio_frame_cache_queue = flume::bounded(32);
+        let video_frame_cache_queue = flume::bounded(32);
+        let audio_decode_thread_notify=Arc::new(Notify::new());
+        let video_decode_thread_notify=Arc::new(Notify::new());
         let tiny_decoder = crate::decode::TinyDecoder::new(
             rt.clone(),
             media_source_flag.clone(),
             end_ts.clone(),
             hardware_config_flag.clone(),
             colorspace_converter.clone(),
+            audio_frame_cache_queue.clone(),
+            video_frame_cache_queue.clone(),
+            audio_decode_thread_notify.clone(),
+            video_decode_thread_notify.clone()
         )?;
         let tiny_decoder = Arc::new(RwLock::new(tiny_decoder));
         // let used_model = Arc::new(RwLock::new(UsedModel::Empty));
@@ -285,9 +293,14 @@ impl AppUI {
             .runtime_handle(rt)
             .pause_flag(pause_flag.clone())
             .color_space_converter(colorspace_converter.clone())
+            .audio_frame_receiver(audio_frame_cache_queue.1.clone())
+            .video_frame_receiver(video_frame_cache_queue.1.clone())
+            .audio_decode_thread_notify(audio_decode_thread_notify.clone())
+            .video_decode_thread_notify(video_decode_thread_notify.clone())
             .build()?;
-        let present_data_manager = PresentDataManager::new(data_manage_context);
-
+        let mut present_data_manager = PresentDataManager::new(data_manage_context);
+        present_data_manager.start_present_tasks();
+        let present_data_manager=Arc::new(RwLock::new(present_data_manager));
         let bg_dyn_img = Arc::new(dyn_img);
         let garbage_video_texture = Arc::new(RwLock::new(None));
         let live_mode = Arc::new(AtomicBool::new(false));
@@ -306,6 +319,7 @@ impl AppUI {
             .video_texture(video_texture.clone())
             .video_texture_id(video_texture_id.clone())
             .live_mode(live_mode.clone())
+            .present_data_manager(present_data_manager.clone())
             .build()?;
         let internet_list_window_flag = Arc::new(AtomicBool::new(false));
         let internet_resource_ui = InternetResourceUI::new(
@@ -1117,7 +1131,14 @@ impl AppUI {
             context
                 .current_video_timestamp
                 .store(0, std::sync::atomic::Ordering::Release);
+            {
+            let mut present_data_manager=context.present_data_manager.write().await;
+            if let Err(e)=present_data_manager.stop_present_tasks(){
+                warn!("{:?}",e);
+            }
+            
             let mut tiny_decoder = context.tiny_decoder.write().await;
+            
             if let Err(e) = tiny_decoder.set_file_path_and_init_par(&context.path).await {
                 warn!("{}", e);
             }
@@ -1147,6 +1168,8 @@ impl AppUI {
                 warn!("{}", e);
             }
             info!("reset video texture success");
+            present_data_manager.start_present_tasks();
+            }
         });
 
         Ok(())
@@ -1431,4 +1454,5 @@ pub struct ChangeInputContext {
     video_texture: Arc<RwLock<Texture>>,
     pub runtime_handle: Handle,
     pub live_mode: Arc<AtomicBool>,
+    present_data_manager:Arc<RwLock<PresentDataManager>>
 }

--- a/src/audio_play.rs
+++ b/src/audio_play.rs
@@ -7,7 +7,7 @@ use rodio::{
 };
 
 use crate::PlayerResult;
-
+pub const AUDIO_SAMPLE_RATE: u32 = 48000;
 pub struct AudioPlayer {
     _device_sink: MixerDeviceSink,
     sink: Arc<Player>,
@@ -41,9 +41,7 @@ impl AudioPlayer {
         sink: &Player,
         audio_frame: ffmpeg_the_third::frame::Audio,
     ) -> PlayerResult<()> {
-        let audio_data = bytemuck::cast_slice::<u8, f32>(audio_frame.data(0));
-        let audio_data =
-            &audio_data[0..audio_frame.samples() * audio_frame.ch_layout().channels() as usize];
+        let audio_data = bytemuck::cast_slice::<u8, f32>(&audio_frame.data(0)[0..(size_of::<f32>()*audio_frame.samples() * audio_frame.ch_layout().channels() as usize)]);
         let source = rodio::buffer::SamplesBuffer::new(
             NonZero::new(audio_frame.ch_layout().channels() as u16)
                 .context("construct nonzero err")?,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -32,7 +32,7 @@ use tokio::{
 };
 use tracing::{Instrument, Level, info, span, warn};
 
-use crate::{PlayerResult, gpu_post_process::ColorSpaceConverter};
+use crate::{PlayerResult, audio_play::AUDIO_SAMPLE_RATE, gpu_post_process::ColorSpaceConverter};
 /// this wrapper type should be protected manually to
 /// keep memory safe in multi threads
 /// means need to wrap an Arc and a Lock to use it in multi threads
@@ -86,7 +86,7 @@ pub struct TinyDecoder {
     format_input: Arc<RwLock<Option<ManualProtectedInput>>>,
     video_decoder: Arc<RwLock<Option<ManualProtectedVideoDecoder>>>,
     audio_decoder: Arc<RwLock<Option<ManualProtectedAudioDecoder>>>,
-    resampler_ctx: Option<ManualProtectedResampler>,
+    resampler: Arc<RwLock<Option<ManualProtectedResampler>>>,
     video_frame_cache_queue: (
         Sender<ffmpeg_the_third::frame::Video>,
         Receiver<ffmpeg_the_third::frame::Video>,
@@ -126,8 +126,19 @@ impl TinyDecoder {
         end_timestamp: Arc<AtomicI64>,
         hardware_config_flag: Arc<AtomicBool>,
         color_space_converter: Arc<RwLock<ColorSpaceConverter>>,
+        audio_frame_cache_queue: (
+            Sender<ffmpeg_the_third::frame::Audio>,
+            Receiver<ffmpeg_the_third::frame::Audio>,
+        ),
+        video_frame_cache_queue: (
+            Sender<ffmpeg_the_third::frame::Video>,
+            Receiver<ffmpeg_the_third::frame::Video>,
+        ),
+        audio_decode_thread_notify: Arc<Notify>,
+        video_decode_thread_notify: Arc<Notify>,
     ) -> PlayerResult<Self> {
         ffmpeg_the_third::init()?;
+        let resampler = Arc::new(RwLock::new(None));
         Ok(Self {
             video_stream_index: usize::MAX,
             audio_stream_index: usize::MAX,
@@ -142,9 +153,8 @@ impl TinyDecoder {
             format_input: Arc::new(RwLock::new(None)),
             video_decoder: Arc::new(RwLock::new(None)),
             audio_decoder: Arc::new(RwLock::new(None)),
-            resampler_ctx: None,
-            video_frame_cache_queue: flume::bounded(16),
-            audio_frame_cache_queue: flume::bounded(32),
+            video_frame_cache_queue,
+            audio_frame_cache_queue,
             audio_packet_cache_queue: flume::bounded(512),
             video_packet_cache_queue: flume::bounded(512),
             demux_exit_flag: Arc::new(AtomicBool::new(false)),
@@ -156,10 +166,10 @@ impl TinyDecoder {
             cover_pic_data: Arc::new(RwLock::new(None)),
             runtime_handle,
             demux_thread_notify: Arc::new(Notify::new()),
-            audio_decode_thread_notify: Arc::new(Notify::new()),
-            video_decode_thread_notify: Arc::new(Notify::new()),
+            audio_decode_thread_notify,
+            video_decode_thread_notify,
             color_space_converter,
-
+            resampler,
             media_source_flag,
         })
     }
@@ -171,7 +181,17 @@ impl TinyDecoder {
         self.cover_stream_index = usize::MAX;
         self.main_stream = MainStream::Audio;
         *self.audio_decoder.write().await = None;
+
         self.audio_time_base = Rational::new(1, 1);
+        {
+            let mut resampler = self.resampler.write().await;
+            if let Ok(ctx) = resampler.as_mut().context("no resampler") {
+                unsafe {
+                    swr_free(&mut ctx.0);
+                }
+            }
+            *resampler = None;
+        }
         self.cover_pic_data = Arc::new(RwLock::new(None));
         self.video_decode_task_handle = None;
         self.audio_decode_task_handle = None;
@@ -187,7 +207,6 @@ impl TinyDecoder {
         *self.format_input.write().await = None;
         self.hardware_config_flag
             .store(false, std::sync::atomic::Ordering::Relaxed);
-        self.resampler_ctx = None;
         *self.video_decoder.write().await = None;
         self.video_frame_rect = [0, 0];
         self.video_time_base = Rational::new(1, 1);
@@ -342,13 +361,13 @@ impl TinyDecoder {
                     audio_decoder.ch_layout().channels(),
                 ));
             }
-            unsafe {
+            let resampler = unsafe {
                 let mut swr_ctx = null_mut();
                 let r = swr_alloc_set_opts2(
                     &mut swr_ctx,
                     &AV_CHANNEL_LAYOUT_STEREO,
                     ffmpeg_the_third::ffi::AVSampleFormat::FLT,
-                    48000,
+                    AUDIO_SAMPLE_RATE as i32,
                     audio_decoder.ch_layout().as_ptr(),
                     audio_format,
                     audio_decoder.rate() as i32,
@@ -362,8 +381,10 @@ impl TinyDecoder {
                 if r < 0 {
                     info!("swr init err");
                 }
-                self.resampler_ctx = Some(ManualProtectedResampler(swr_ctx));
-            }
+                ManualProtectedResampler(swr_ctx)
+            };
+            let mut resampler_guard = self.resampler.write().await;
+            *resampler_guard = Some(resampler);
             {
                 let mut a_decoder = self.audio_decoder.write().await;
                 *a_decoder = Some(ManualProtectedAudioDecoder(audio_decoder));
@@ -718,16 +739,33 @@ impl TinyDecoder {
                     let mut audio_decoder = decode_context.audio_decoder.write().await;
                     if let Some(decoder) = &mut *audio_decoder {
                         if decoder.0.send_packet(&packet).is_ok() {
+                            let mut resampler = decode_context.resampler.write().await;
+                            let resampler = resampler.as_mut().context("no resampler allocated")?;
                             loop {
                                 let mut audio_frame_tmp = ffmpeg_the_third::frame::Audio::empty();
 
                                 if decoder.0.receive_frame(&mut audio_frame_tmp).is_err() {
                                     break;
                                 }
-
+                                let mut resampled_frame = Audio::empty();
+                                resampled_frame.set_ch_layout(ChannelLayout::STEREO);
+                                resampled_frame.set_rate(AUDIO_SAMPLE_RATE);
+                                resampled_frame.set_format(Sample::F32(Type::Packed));
+                                resampled_frame.set_pts(audio_frame_tmp.pts());
+                                unsafe {
+                                    if swr_convert_frame(
+                                        resampler.0,
+                                        resampled_frame.as_mut_ptr(),
+                                        audio_frame_tmp.as_ptr(),
+                                    ) != 0
+                                    {
+                                        warn!("convert audio frame err, but still in decoding!!!");
+                                        return Err(anyhow::Error::msg("convert audio frame err"));
+                                    }
+                                }
                                 if let Err(e) = decode_context
                                     .audio_frame_sender
-                                    .send_async(audio_frame_tmp)
+                                    .send_async(resampled_frame)
                                     .await
                                 {
                                     warn!("{}", e);
@@ -796,6 +834,7 @@ impl TinyDecoder {
             .decode_exit_flag(self.decode_exit_flag.clone())
             .audio_decode_thread_notify(self.audio_decode_thread_notify.clone())
             .demux_thread_notify(self.demux_thread_notify.clone())
+            .resampler(self.resampler.clone())
             .build()
         {
             self.audio_decode_task_handle = Some(self.runtime_handle.spawn(async move {
@@ -809,45 +848,7 @@ impl TinyDecoder {
             warn!("build decode context error!");
         }
     }
-    /// called by the main thread pull one audio frame from the queue
-    /// in addition, do the resample
-    pub async fn pull_one_audio_play_frame(&mut self) -> Option<ffmpeg_the_third::frame::Audio> {
-        if let Some(resampler_ctx) = &mut self.resampler_ctx {
-            let mut res = ffmpeg_the_third::frame::Audio::empty();
-            res.set_format(ffmpeg_the_third::format::Sample::F32(Type::Packed));
-            res.set_ch_layout(ChannelLayout::STEREO);
-            res.set_rate(48000);
 
-            {
-                if self.audio_frame_cache_queue.1.len() < 10 {
-                    self.audio_decode_thread_notify.notify_one();
-                }
-                if !self.audio_frame_cache_queue.1.is_empty() {
-                    if let Ok(raw_frame) = self.audio_frame_cache_queue.1.recv_async().await {
-                        // info!("channel len{}", self.audio_frame_cache_queue.1.len());
-                        unsafe {
-                            let r = swr_convert_frame(
-                                resampler_ctx.0,
-                                res.as_mut_ptr(),
-                                raw_frame.as_ptr(),
-                            );
-                            if r == 0 {
-                                if let Some(pts) = raw_frame.pts() {
-                                    res.set_pts(Some(pts));
-                                    res.set_rate(48000);
-                                    return Some(res);
-                                }
-                            } else {
-                                info!("resample err{}", r);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        None
-    }
     pub async fn _convert_frame_data_to_no_padding_layout(res: &mut Video) -> Box<[u8]> {
         unsafe {
             let buf_size = av_image_get_buffer_size(
@@ -875,20 +876,6 @@ impl TinyDecoder {
         }
     }
 
-    /// pull one frame from the video cache queue
-    /// in additon, do the convert and if the input changed(caused by source or hard acce)
-    /// set the new converter, only change the out put format, dont change the width and height which
-    /// have been used in the ui thread
-    pub async fn pull_one_video_play_frame(&mut self) -> Option<ffmpeg_the_third::frame::Video> {
-        if self.video_frame_cache_queue.1.len() < 5 {
-            self.video_decode_thread_notify.notify_one();
-        }
-        if !self.video_frame_cache_queue.1.is_empty() {
-            self.video_frame_cache_queue.1.recv_async().await.ok()
-        } else {
-            None
-        }
-    }
     /// get v time base used to check time and compare to sync
     pub fn video_time_base(&self) -> &Rational {
         &self.video_time_base
@@ -1128,8 +1115,8 @@ impl Drop for TinyDecoder {
             info!("demux and decode thread exit gracefully");
             PlayerResult::Ok(())
         });
-
-        if let Some(ctx) = &mut self.resampler_ctx {
+        let mut resampler = self.resampler.blocking_write();
+        if let Ok(ctx) = resampler.as_mut().context("no resampler") {
             unsafe {
                 swr_free(&mut ctx.0);
             }
@@ -1169,4 +1156,5 @@ struct AudioDecodeContext {
     pub decode_exit_flag: Arc<AtomicBool>,
     pub demux_thread_notify: Arc<Notify>,
     pub audio_decode_thread_notify: Arc<Notify>,
+    pub resampler: Arc<RwLock<Option<ManualProtectedResampler>>>,
 }

--- a/src/present_data_manage.rs
+++ b/src/present_data_manage.rs
@@ -6,34 +6,34 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anyhow::Context;
 use derive_builder::Builder;
 use eframe::wgpu::Texture;
-use ffmpeg_the_third::Rational;
+use ffmpeg_the_third::{
+    Rational,
+    frame::{Audio, Video},
+};
+use flume::Receiver;
 use rodio::Player;
-use tokio::{runtime::Handle, sync::RwLock, task::JoinHandle, time::sleep};
+use tokio::{runtime::Handle, sync::{Notify, RwLock}, task::JoinHandle, time::sleep};
 use tracing::warn;
 
 use crate::{
-    audio_play::AudioPlayer,
-    decode::{MainStream, TinyDecoder},
-    gpu_post_process::ColorSpaceConverter,
+    PlayerResult, audio_play::AudioPlayer, decode::{MainStream, TinyDecoder}, gpu_post_process::ColorSpaceConverter
 };
 
 pub struct PresentDataManager {
-    _audio_thread_handle: JoinHandle<()>,
-    _video_thread_handle: JoinHandle<()>,
+    audio_thread_handle: Option<JoinHandle<()>>,
+    video_thread_handle: Option<JoinHandle<()>>,
+    data_manage_context: DataManageContext
 }
 impl PresentDataManager {
     pub fn new(data_manage_context: DataManageContext) -> Self {
-        let runtime_handle = data_manage_context.runtime_handle.clone();
-        let _audio_thread_handle = runtime_handle.spawn(PresentDataManager::play_audio_task(
-            data_manage_context.clone(),
-        ));
-        let _video_thread_handle =
-            runtime_handle.spawn(PresentDataManager::play_video_task(data_manage_context));
+        
         Self {
-            _audio_thread_handle,
-            _video_thread_handle,
+            audio_thread_handle:None,
+            video_thread_handle:None,
+            data_manage_context
         }
     }
     async fn play_audio_task(data_manage_context: DataManageContext) {
@@ -48,32 +48,36 @@ impl PresentDataManager {
                 && data_manage_context.audio_sink.len() < 10
             {
                 let mainstream = {
-                    let mut tiny_decoder = data_manage_context.tiny_decoder.write().await;
-                    if let MainStream::Audio = tiny_decoder.main_stream() {
-                        if let Some(audio_frame) = tiny_decoder.pull_one_audio_play_frame().await {
-                            if let Some(pts) = audio_frame.pts() {
-                                audio_cur_ts = Some(pts);
-                                if let Err(e) = AudioPlayer::play_raw_data_from_audio_frame(
-                                    &data_manage_context.audio_sink,
-                                    audio_frame.clone(),
-                                )
-                                .await
-                                {
-                                    warn!("{}", e);
-                                }
-                                // let used_model = data_manage_context.used_model.read().await;
-                                // let used_model_ref = &*used_model;
-                                // if UsedModel::Empty != *used_model_ref {
-                                //     let mut ai_subtitle = data_manage_context.ai_subtitle.write().await;
-                                //     let used_model = used_model_ref.clone();
-                                //     ai_subtitle.push_frame_data(audio_frame, used_model).await;
-                                // }
-                            }
-                        }
-                    }
-
+                    let tiny_decoder = data_manage_context.tiny_decoder.read().await;
                     tiny_decoder.main_stream().clone()
                 };
+                if let MainStream::Audio = &mainstream {
+                    if data_manage_context.audio_frame_receiver.len()<5{
+                        data_manage_context.audio_decode_thread_notify.notify_one();
+                    }
+                    if let Ok(audio_frame) =
+                        data_manage_context.audio_frame_receiver.recv_async().await
+                    {
+                        if let Some(pts) = audio_frame.pts() {
+                            audio_cur_ts = Some(pts);
+                            if let Err(e) = AudioPlayer::play_raw_data_from_audio_frame(
+                                &data_manage_context.audio_sink,
+                                audio_frame.clone(),
+                            )
+                            .await
+                            {
+                                warn!("{}", e);
+                            }
+                            // let used_model = data_manage_context.used_model.read().await;
+                            // let used_model_ref = &*used_model;
+                            // if UsedModel::Empty != *used_model_ref {
+                            //     let mut ai_subtitle = data_manage_context.ai_subtitle.write().await;
+                            //     let used_model = used_model_ref.clone();
+                            //     ai_subtitle.push_frame_data(audio_frame, used_model).await;
+                            // }
+                        }
+                    }
+                }
 
                 PresentDataManager::update_current_timestamp(
                     data_manage_context.main_stream_current_timestamp.clone(),
@@ -91,7 +95,7 @@ impl PresentDataManager {
         loop {
             if !data_manage_context
                 .pause_flag
-                .load(std::sync::atomic::Ordering::Acquire)
+                .load(std::sync::atomic::Ordering::Relaxed)
             {
                 let (main_stream, audio_time_base, video_time_base) = {
                     let tiny_decoder = data_manage_context.tiny_decoder.read().await;
@@ -101,6 +105,7 @@ impl PresentDataManager {
                         *tiny_decoder.video_time_base(),
                     )
                 };
+                
                 if PresentDataManager::should_video_catch_audio(
                     main_stream.clone(),
                     audio_time_base,
@@ -110,13 +115,15 @@ impl PresentDataManager {
                 )
                 .await
                 {
-                    let mut tiny_decoder = data_manage_context.tiny_decoder.write().await;
                     let ins_now = Instant::now();
-
+                    if data_manage_context.video_frame_receiver.len()<10{
+                        data_manage_context.video_decode_thread_notify.notify_one();
+                    }
                     let frame_result = match &main_stream {
                         MainStream::Video => {
                             if ins_now.checked_duration_since(change_instant).is_some() {
-                                if let Some(frame) = tiny_decoder.pull_one_video_play_frame().await
+                                if let Ok(frame) =
+                                    data_manage_context.video_frame_receiver.recv_async().await
                                 {
                                     if let Some(f_pts) = frame.pts() {
                                         let cur_pts = data_manage_context
@@ -159,7 +166,9 @@ impl PresentDataManager {
                             }
                         }
                         MainStream::Audio => {
-                            if let Some(frame) = tiny_decoder.pull_one_video_play_frame().await {
+                            if let Ok(frame) =
+                                data_manage_context.video_frame_receiver.recv_async().await
+                            {
                                 if let Some(pts) = frame.pts() {
                                     data_manage_context
                                         .current_video_timestamp
@@ -174,6 +183,7 @@ impl PresentDataManager {
                     if let Ok(frame) = frame_result {
                         let mut color_space_converter =
                             data_manage_context.color_space_converter.write().await;
+                        
                         if let Err(e) = color_space_converter
                             .render_video(data_manage_context.video_texture.clone(), frame)
                             .await
@@ -195,16 +205,18 @@ impl PresentDataManager {
         /*
         add audio frame data to the audio player
          */
-
-        if let MainStream::Audio = main_stream {
-            if let Some(pts) = audio_pts {
-                // info!("store main  timestamp:{}",pts);
+        match main_stream {
+            MainStream::Audio => {
+                if let Some(pts) = audio_pts {
+                    // info!("store main  timestamp:{}",pts);
+                    main_stream_current_timestamp.store(pts, std::sync::atomic::Ordering::Release);
+                }
+            }
+            MainStream::Video => {
+                let pts = current_video_timestamp.load(std::sync::atomic::Ordering::Relaxed);
                 main_stream_current_timestamp.store(pts, std::sync::atomic::Ordering::Release);
             }
-        } else if let MainStream::Video = main_stream {
-            let pts = current_video_timestamp.load(std::sync::atomic::Ordering::Relaxed);
-            main_stream_current_timestamp.store(pts, std::sync::atomic::Ordering::Release);
-        }
+        };
     }
     /// if video time-audio time is too high(more than 1 second),default return true
     async fn should_video_catch_audio(
@@ -234,6 +246,19 @@ impl PresentDataManager {
 
         false
     }
+    pub fn stop_present_tasks(&self)->PlayerResult<()>{
+        let audio_task_join_handle = self.audio_thread_handle.as_ref().context("no audio play task running")?;
+        audio_task_join_handle.abort();
+        let video_task_join_handle = self.video_thread_handle.as_ref().context("no video play task running")?;
+        video_task_join_handle.abort();
+        Ok(())
+    }
+    pub fn start_present_tasks(&mut self){
+        let runtime_handle = self.data_manage_context.runtime_handle.clone();
+        self.audio_thread_handle=Some(runtime_handle.spawn(Self::play_audio_task(self.data_manage_context.clone())));
+        
+        self.video_thread_handle=Some(runtime_handle.spawn(Self::play_video_task(self.data_manage_context.clone())));
+    }
 }
 #[derive(Builder, Clone)]
 pub struct DataManageContext {
@@ -247,4 +272,8 @@ pub struct DataManageContext {
     video_texture: Arc<RwLock<Texture>>,
     pause_flag: Arc<AtomicBool>,
     color_space_converter: Arc<RwLock<ColorSpaceConverter>>,
+    audio_frame_receiver: Receiver<Audio>,
+    video_frame_receiver: Receiver<Video>,
+    audio_decode_thread_notify:Arc<Notify>,
+    video_decode_thread_notify:Arc<Notify>,
 }


### PR DESCRIPTION
…aceConverter from TinyDecoder, move resampling to audio decode task which reduces jitter in play task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio and video frame synchronization during playback.

* **Improvements**
  * Optimized decode and presentation pipeline for improved efficiency and reliability.
  * Refined audio resampling performance in the decode worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->