### PR TITLE
Enhancing end_ts computing fallback logic

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -288,23 +288,27 @@ impl TinyDecoder {
             }
         }
         if end_ts == AV_NOPTS_VALUE {
-            info!("could not find duration in A/V streams, fallback to input duration");
-            let mut temp_ts = i64::MAX;
-            if audio_stream.is_some() {
-                temp_ts = temp_ts.min(
-                    format_duration * self.audio_time_base.denominator() as i64
-                        / self.audio_time_base.numerator() as i64
-                        / 1000000,
-                );
+            if format_duration != AV_NOPTS_VALUE {
+                info!("could not find duration in A/V streams, fallback to input duration");
+                let mut temp_ts = i64::MAX;
+                if audio_stream.is_some() {
+                    temp_ts = temp_ts.min(
+                        format_duration * self.audio_time_base.denominator() as i64
+                            / self.audio_time_base.numerator() as i64
+                            / 1000000,
+                    );
+                }
+                if video_stream.is_some() {
+                    temp_ts = temp_ts.min(
+                        format_duration * self.video_time_base.denominator() as i64
+                            / self.video_time_base.numerator() as i64
+                            / 1000000,
+                    );
+                }
+                end_ts = temp_ts;
+            } else {
+                end_ts = 0;
             }
-            if video_stream.is_some() {
-                temp_ts = temp_ts.min(
-                    format_duration * self.video_time_base.denominator() as i64
-                        / self.video_time_base.numerator() as i64
-                        / 1000000,
-                );
-            }
-            end_ts = temp_ts;
         }
         self.end_timestamp
             .store(end_ts, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timestamp handling in the decoder for scenarios where audio/video stream duration information is unavailable. The system now properly validates duration data before computing end timestamps, reducing errors when processing files with incomplete stream metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lori-Shu/tiny-player/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->