### PR TITLE
Refactoring playback end detection logic

### DIFF
--- a/src/appui.rs
+++ b/src/appui.rs
@@ -59,6 +59,7 @@ struct UIFlags {
     visible_flag: Arc<AtomicBool>,
     media_source_flag: Arc<AtomicBool>,
     live_mode: Arc<AtomicBool>,
+    theme_flag: bool,
 }
 /// the main struct stores all the vars which are related to ui
 pub struct AppUI {
@@ -76,7 +77,6 @@ pub struct AppUI {
     subtitle_str: String,
     visible_num: Arc<AtomicU32>,
     wgpu_render_state: Arc<RenderState>,
-    end_ts: Arc<AtomicI64>,
     reset_input_context: ResetInputContext,
     time_formatter: OwnedFormatItem,
     keep_awake: Option<KeepAwake>,
@@ -88,25 +88,18 @@ pub struct AppUI {
 impl eframe::App for AppUI {
     /// this function will automaticly be called every ui redraw
     fn ui(&mut self, ui: &mut Ui, _frame: &mut eframe::Frame) {
+        if !self.ui_flags.theme_flag {
+            apply_player_visual(ui);
+            replace_fonts(ui);
+            apply_player_style(ui);
+            self.ui_flags.theme_flag = true;
+            info!("set theme success");
+        }
         egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.vertical(|ui| {
                 // Following is the logic of ui painting
                 if self.manage_keepawake().is_err() {
                     warn!("manage keepawake err!");
-                }
-                if self
-                    .ui_flags
-                    .media_source_flag
-                    .load(std::sync::atomic::Ordering::Acquire)
-                    && !self
-                        .ui_flags
-                        .pause_flag
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                    && self.is_play_end()
-                {
-                    self.ui_flags
-                        .pause_flag
-                        .store(true, std::sync::atomic::Ordering::Release);
                 }
 
                 self.clear_garbage_texture();
@@ -144,42 +137,6 @@ impl eframe::App for AppUI {
     }
 }
 impl AppUI {
-    pub fn replace_fonts(&self, ctx: &egui::Context) {
-        // Start with the default fonts (we will be adding to them rather than replacing them).
-        let mut fonts = egui::FontDefinitions::default();
-
-        // Install my own font (maybe supporting non-latin characters).
-        // .ttf and .otf files supported.
-        fonts.font_data.insert(
-            "app_default_font".to_owned(),
-            std::sync::Arc::new(egui::FontData::from_static(MAPLE_FONT)),
-        );
-        fonts.font_data.insert(
-            "noto_emoji".to_owned(),
-            Arc::new(egui::FontData::from_static(EMOJI_FONT)),
-        );
-        // Put my font first (highest priority) for proportional text:
-        fonts
-            .families
-            .entry(egui::FontFamily::Proportional)
-            .or_default()
-            .insert(0, "app_default_font".to_owned());
-
-        // Put my font as last fallback for monospace:
-        fonts
-            .families
-            .entry(egui::FontFamily::Monospace)
-            .or_default()
-            .insert(0, "app_default_font".to_owned());
-
-        fonts
-            .families
-            .entry(egui::FontFamily::Proportional)
-            .or_default()
-            .insert(1, "noto_emoji".to_owned());
-        // Tell egui to use these fonts:
-        ctx.set_fonts(fonts);
-    }
     pub fn new(cc: &CreationContext) -> PlayerResult<Self> {
         let play_time = time::Time::from_hms(0, 0, 0)?;
 
@@ -222,6 +179,7 @@ impl AppUI {
         let video_decode_thread_notify = Arc::new(Notify::new());
         let current_main_stream_timestamp = Arc::new(AtomicI64::new(0));
         let current_video_timestamp = Arc::new(AtomicI64::new(0));
+        let demux_eof_flag = Arc::new(AtomicBool::new(false));
         let tiny_decoder_creation_args = TinyDecoderCreationArgs::builder()
             .runtime_handle(rt.clone())
             .media_source_flag(media_source_flag.clone())
@@ -233,6 +191,7 @@ impl AppUI {
             .audio_decode_thread_notify(audio_decode_thread_notify.clone())
             .video_decode_thread_notify(video_decode_thread_notify.clone())
             .current_video_timestamp(current_video_timestamp.clone())
+            .demux_eof_flag(demux_eof_flag.clone())
             .build();
         let tiny_decoder = Arc::new(RwLock::new(crate::decode_engine::TinyDecoder::new(
             tiny_decoder_creation_args,
@@ -242,7 +201,7 @@ impl AppUI {
         let audio_player = Arc::new(crate::audio_playback::AudioPlayer::new()?);
 
         let pause_flag = Arc::new(AtomicBool::new(false));
-
+        let live_mode = Arc::new(AtomicBool::new(false));
         let (video_texture_id, video_texture) =
             Self::alloc_texture(main_color_image.clone(), wgpu_render_state.clone());
         let presentation_cancellation_token = Arc::new(CancellationToken::new());
@@ -258,7 +217,7 @@ impl AppUI {
         let transcriber = Arc::new(RwLock::new(Transcriber::new(transcriber_args)?));
         let audio_play_context = AudioPlayContext::builder()
             .audio_decode_thread_notify(audio_decode_thread_notify)
-            .audio_frame_receiver(audio_frame_cache_queue.1)
+            .audio_frame_receiver(audio_frame_cache_queue.1.clone())
             .audio_player(audio_player.clone())
             .cancellation_token(presentation_cancellation_token.clone())
             .current_main_stream_timestamp(current_main_stream_timestamp.clone())
@@ -268,6 +227,9 @@ impl AppUI {
             .tiny_decoder(tiny_decoder.clone())
             .transcriber(transcriber)
             .used_model(used_model.clone())
+            .video_frame_receiver(video_frame_cache_queue.1.clone())
+            .demux_eof_flag(demux_eof_flag.clone())
+            .live_mode(live_mode.clone())
             .build();
         let video_play_context = VideoPlayContext::builder()
             .cancellation_token(presentation_cancellation_token.clone())
@@ -280,6 +242,9 @@ impl AppUI {
             .video_decode_thread_notify(video_decode_thread_notify)
             .video_frame_receiver(video_frame_cache_queue.1)
             .video_texture(video_texture.clone())
+            .audio_frame_receiver(audio_frame_cache_queue.1.clone())
+            .demux_eof_flag(demux_eof_flag.clone())
+            .live_mode(live_mode.clone())
             .build();
         let present_data_manager = PresentDataManager::new(
             rt.clone(),
@@ -290,7 +255,6 @@ impl AppUI {
         let present_data_manager = Arc::new(RwLock::new(present_data_manager));
         let bg_dyn_img = Arc::new(dyn_img);
         let garbage_video_texture_queue = bounded(8);
-        let live_mode = Arc::new(AtomicBool::new(false));
         let tip_window_flag = Arc::new(AtomicBool::new(false));
         let tip_window_msg = Arc::new(RwLock::new("empty msg".to_string()));
         let reset_input_context = ResetInputContext::builder()
@@ -368,6 +332,7 @@ impl AppUI {
             .visible_flag(visible_flag.clone())
             .visible_num(visible_num.clone())
             .build();
+        let theme_flag = false;
         Ok(Self {
             async_runtime,
             garbage_video_texture_receiver: garbage_video_texture_queue.1,
@@ -384,11 +349,11 @@ impl AppUI {
                 visible_flag,
                 media_source_flag,
                 live_mode,
+                theme_flag,
             },
             tip_window_msg,
             visible_num,
             wgpu_render_state,
-            end_ts,
             reset_input_context,
             time_formatter,
             keep_awake,
@@ -646,17 +611,11 @@ impl AppUI {
                         .tint(Color32::from_white_alpha((255.0 * visible_num) as u8))
                         .atom_size(btn_rect);
                     let play_or_pause_btn = egui::Button::new(btn_img)
-                        .fill(egui::Color32::from_rgba_unmultiplied(
-                            0,
-                            0,
-                            0,
-                            (10.0 * visible_num) as u8,
-                        ))
+                        .fill(egui::Color32::from_white_alpha((10.0 * visible_num) as u8))
                         .stroke(Stroke::new(
                             1.0,
-                            Color32::from_rgba_unmultiplied(0, 0, 0, (10.0 * visible_num) as u8),
-                        ))
-                        .corner_radius(CornerRadius::from(30));
+                            Color32::from_white_alpha((10.0 * visible_num) as u8),
+                        ));
 
                     let btn_response = ui.add(play_or_pause_btn);
                     if btn_response.hovered() {
@@ -714,24 +673,6 @@ impl AppUI {
         });
     }
 
-    fn is_play_end(&self) -> bool {
-        if !self
-            .ui_flags
-            .live_mode
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
-            let pts = self
-                .current_main_stream_timestamp
-                .load(std::sync::atomic::Ordering::Relaxed);
-            let end_ts = self.end_ts.load(std::sync::atomic::Ordering::Relaxed);
-            if pts >= end_ts {
-                warn!("play end! end_ts:{end_ts},current_ts:{pts} ");
-                return true;
-            }
-        }
-        false
-    }
-
     async fn reset_main_colorimg_to_bg(
         bg_dyn_img: Arc<DynamicImage>,
         video_rect: &[u32; 2],
@@ -764,7 +705,7 @@ impl AppUI {
         tiny_decoder: &TinyDecoder,
         main_color_image: Arc<RwLock<ColorImage>>,
     ) {
-        let cover_pic_data = tiny_decoder.cover_pic_data.clone();
+        let cover_pic_data = tiny_decoder.get_cover_pic_data();
         let cover_data = cover_pic_data.read().await;
         if let Some(data_vec) = &*cover_data
             && let Ok(img) = image::load_from_memory(data_vec)
@@ -1036,6 +977,66 @@ impl Drop for AppUI {
     fn drop(&mut self) {
         self.free_texture();
     }
+}
+fn apply_player_visual(ctx: &Ui) {
+    let mut visuals = egui::Visuals::dark();
+
+    visuals.panel_fill = egui::Color32::from_rgb(15, 23, 42);
+
+    visuals.widgets.inactive.bg_fill = egui::Color32::from_rgb(30, 41, 59);
+    visuals.widgets.hovered.bg_fill = egui::Color32::from_rgb(51, 65, 85);
+
+    visuals.widgets.active.bg_fill = egui::Color32::from_rgb(6, 182, 212);
+    visuals.selection.bg_fill = egui::Color32::from_rgb(6, 182, 212).linear_multiply(0.3);
+
+    ctx.set_visuals(visuals);
+}
+fn apply_player_style(ctx: &Ui) {
+    let mut style = (*ctx.global_style()).clone();
+
+    style.visuals.widgets.inactive.corner_radius = egui::CornerRadius::same(8);
+    style.visuals.widgets.hovered.corner_radius = egui::CornerRadius::same(8);
+
+    style.spacing.button_padding = egui::vec2(12.0, 6.0);
+    style.spacing.item_spacing = egui::vec2(10.0, 10.0);
+
+    ctx.set_global_style(style);
+}
+fn replace_fonts(ctx: &Ui) {
+    // Start with the default fonts (we will be adding to them rather than replacing them).
+    let mut fonts = egui::FontDefinitions::default();
+
+    // Install my own font (maybe supporting non-latin characters).
+    // .ttf and .otf files supported.
+    fonts.font_data.insert(
+        "app_default_font".to_owned(),
+        std::sync::Arc::new(egui::FontData::from_static(MAPLE_FONT)),
+    );
+    fonts.font_data.insert(
+        "noto_emoji".to_owned(),
+        Arc::new(egui::FontData::from_static(EMOJI_FONT)),
+    );
+    // Put my font first (highest priority) for proportional text:
+    fonts
+        .families
+        .entry(egui::FontFamily::Proportional)
+        .or_default()
+        .insert(0, "app_default_font".to_owned());
+
+    // Put my font as last fallback for monospace:
+    fonts
+        .families
+        .entry(egui::FontFamily::Monospace)
+        .or_default()
+        .insert(0, "app_default_font".to_owned());
+
+    fonts
+        .families
+        .entry(egui::FontFamily::Proportional)
+        .or_default()
+        .insert(1, "noto_emoji".to_owned());
+    // Tell egui to use these fonts:
+    ctx.set_fonts(fonts);
 }
 pub struct VideoDes {
     pub name: String,

--- a/src/controlbar_ui.rs
+++ b/src/controlbar_ui.rs
@@ -5,9 +5,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicI64, AtomicU32},
 };
 
-use egui::{
-    AtomExt, Button, Color32, CornerRadius, Image, Layout, RichText, Stroke, Ui, Vec2, WidgetText,
-};
+use egui::{AtomExt, Button, Color32, Image, Layout, RichText, Stroke, Ui, Vec2, WidgetText};
 use tokio::{
     runtime::Handle,
     sync::{Notify, RwLock},
@@ -85,7 +83,7 @@ impl ControlbarUI {
                 )));
 
             let mut slider_width_style = egui::style::Style::default();
-            slider_width_style.spacing.slider_width = ui.ctx().content_rect().width() - 450.0;
+            slider_width_style.spacing.slider_width = ui.ctx().content_rect().width() / 2.0;
             slider_width_style.spacing.slider_rail_height = 10.0;
             slider_width_style.spacing.interact_size = Vec2::new(20.0, 20.0);
             slider_width_style.visuals.extreme_bg_color =
@@ -124,17 +122,11 @@ impl ControlbarUI {
                     .tint(Color32::from_white_alpha((255.0 * visible_num) as u8))
                     .atom_size(Vec2::new(50.0, 50.0)),
             )
-            .fill(egui::Color32::from_rgba_unmultiplied(
-                0,
-                0,
-                0,
-                (10.0 * visible_num) as u8,
-            ))
+            .fill(egui::Color32::from_white_alpha((10.0 * visible_num) as u8))
             .stroke(Stroke::new(
                 1.0,
-                Color32::from_rgba_unmultiplied(0, 0, 0, (10.0 * visible_num) as u8),
-            ))
-            .corner_radius(CornerRadius::from(30));
+                Color32::from_white_alpha((10.0 * visible_num) as u8),
+            ));
             let btn_response = ui.add(subtitle_btn);
             if btn_response.hovered() {
                 self.visible_flag
@@ -184,17 +176,11 @@ impl ControlbarUI {
                     .tint(Color32::from_white_alpha((255.0 * visible_num) as u8))
                     .atom_size(Vec2::new(50.0, 50.0)),
             )
-            .fill(egui::Color32::from_rgba_unmultiplied(
-                0,
-                0,
-                0,
-                (10.0 * visible_num) as u8,
-            ))
+            .fill(egui::Color32::from_white_alpha((10.0 * visible_num) as u8))
             .stroke(Stroke::new(
                 1.0,
-                Color32::from_rgba_unmultiplied(0, 0, 0, (10.0 * visible_num) as u8),
-            ))
-            .corner_radius(CornerRadius::from(30));
+                Color32::from_white_alpha((10.0 * visible_num) as u8),
+            ));
             let btn_response = ui.add(volumn_img_btn);
             if btn_response.hovered() {
                 self.visible_flag
@@ -256,8 +242,7 @@ impl ControlbarUI {
             .stroke(Stroke::new(
                 1.0,
                 Color32::from_white_alpha((10.0 * visible_num) as u8),
-            ))
-            .corner_radius(CornerRadius::from(30));
+            ));
             let btn_response = ui.add(fullscreen_image_btn);
             if btn_response.hovered() {
                 self.visible_flag

--- a/src/decode_engine.rs
+++ b/src/decode_engine.rs
@@ -6,7 +6,6 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicI64},
     },
-    time::Duration,
 };
 
 use anyhow::Context;
@@ -29,7 +28,6 @@ use tokio::{
     runtime::Handle,
     sync::{Notify, RwLock},
     task::JoinHandle,
-    time::sleep,
 };
 use tokio_util::{future::FutureExt, sync::CancellationToken};
 use tracing::{Instrument, Level, info, span, warn};
@@ -108,7 +106,7 @@ pub struct TinyDecoder {
     video_decode_task_handle: Option<JoinHandle<PlayerResult<()>>>,
     audio_decode_task_handle: Option<JoinHandle<PlayerResult<()>>>,
     hardware_config_flag: Arc<AtomicBool>,
-    pub cover_pic_data: Arc<RwLock<Option<Vec<u8>>>>,
+    cover_pic_data: Arc<RwLock<Option<Vec<u8>>>>,
     runtime_handle: Handle,
     demux_thread_notify: Arc<Notify>,
     audio_decode_thread_notify: Arc<Notify>,
@@ -117,6 +115,7 @@ pub struct TinyDecoder {
     media_source_flag: Arc<AtomicBool>,
     current_video_timestamp: Arc<AtomicI64>,
     cancellation_token: Arc<CancellationToken>,
+    demux_eof_flag: Arc<AtomicBool>,
 }
 impl TinyDecoder {
     /// init Decoder and new Struct
@@ -156,6 +155,7 @@ impl TinyDecoder {
             media_source_flag: tiny_decoder_creation_args.media_source_flag,
             current_video_timestamp: tiny_decoder_creation_args.current_video_timestamp,
             cancellation_token,
+            demux_eof_flag: tiny_decoder_creation_args.demux_eof_flag,
         })
     }
     /// reset all fields to the initial state
@@ -189,6 +189,8 @@ impl TinyDecoder {
         self.audio_frame_cache_queue.1.drain();
         self.video_frame_cache_queue.1.drain();
         self.media_source_flag
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.demux_eof_flag
             .store(false, std::sync::atomic::Ordering::Relaxed);
     }
     /// `reset_input` is called when user selected a file path to play
@@ -406,15 +408,11 @@ impl TinyDecoder {
                     if let Some(input) = &mut *input {
                         match input.0.packets().next() {
                             Some(Ok((stream, packet))) => Ok((stream.index(), packet)),
-                            Some(Err(ffmpeg_the_third::util::error::Error::Eof)) => {
-                                info!("demux process hit the end");
-                                Err(anyhow::Error::msg("eof"))
-                            }
-                            None => Err(anyhow::Error::msg("None")),
-                            _ => Err(anyhow::Error::msg("Other case")),
+                            None => Err(anyhow::Error::msg("EOF")),
+                            _ => Err(anyhow::Error::msg("other cases")),
                         }
                     } else {
-                        Err(anyhow::Error::msg("Other case"))
+                        Err(anyhow::Error::msg("other cases"))
                     }
                 };
                 {
@@ -452,8 +450,12 @@ impl TinyDecoder {
                             }
                         }
                         Err(e) => {
-                            if format!("{}", e) == "eof" {
-                                sleep(Duration::from_millis(10)).await;
+                            if e.to_string() == "EOF" {
+                                warn!("demux task detected eof");
+                                demux_context
+                                    .demux_eof_flag
+                                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                                demux_context.demux_thread_notify.notified().await;
                             }
                         }
                     }
@@ -728,6 +730,7 @@ impl TinyDecoder {
             .cover_image_data(self.cover_pic_data.clone())
             .demux_thread_notify(self.demux_thread_notify.clone())
             .cancellation_token(self.cancellation_token.clone())
+            .demux_eof_flag(self.demux_eof_flag.clone())
             .build();
 
         self.demux_task_handle = Some(self.runtime_handle.spawn(async move {
@@ -786,6 +789,8 @@ impl TinyDecoder {
             let mut input = self.format_input.write().await;
             info!("seek timestamp:{}", ts);
             if let Some(input) = &mut *input {
+                self.demux_eof_flag
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 let res = ffmpeg_the_third::ffi::avformat_seek_file(
                     input.0.as_mut_ptr(),
                     main_stream_idx as i32,
@@ -979,6 +984,9 @@ impl TinyDecoder {
             }
         }
     }
+    pub fn get_cover_pic_data(&self) -> Arc<RwLock<Option<Vec<u8>>>> {
+        self.cover_pic_data.clone()
+    }
 }
 unsafe extern "C" fn get_format_callback(
     _ctx: *mut AVCodecContext,
@@ -1043,6 +1051,7 @@ pub struct TinyDecoderCreationArgs {
     audio_decode_thread_notify: Arc<Notify>,
     video_decode_thread_notify: Arc<Notify>,
     current_video_timestamp: Arc<AtomicI64>,
+    demux_eof_flag: Arc<AtomicBool>,
 }
 
 #[derive(TypedBuilder)]
@@ -1056,6 +1065,7 @@ struct DemuxContext {
     cover_image_data: Arc<RwLock<Option<Vec<u8>>>>,
     demux_thread_notify: Arc<Notify>,
     cancellation_token: Arc<CancellationToken>,
+    demux_eof_flag: Arc<AtomicBool>,
 }
 
 #[derive(TypedBuilder)]

--- a/src/decode_engine.rs
+++ b/src/decode_engine.rs
@@ -789,8 +789,6 @@ impl TinyDecoder {
             let mut input = self.format_input.write().await;
             info!("seek timestamp:{}", ts);
             if let Some(input) = &mut *input {
-                self.demux_eof_flag
-                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 let res = ffmpeg_the_third::ffi::avformat_seek_file(
                     input.0.as_mut_ptr(),
                     main_stream_idx as i32,
@@ -810,6 +808,9 @@ impl TinyDecoder {
                     .store(0, std::sync::atomic::Ordering::Release);
 
                 self.flush_decoders().await;
+                self.demux_eof_flag
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.demux_thread_notify.notify_one();
             }
             info!("seek finished!");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,10 +104,7 @@ fn main() {
         Box::new(|cc| {
             egui_extras::install_image_loaders(&cc.egui_ctx);
             match appui::AppUI::new(cc) {
-                Ok(tiny_app_ui) => {
-                    tiny_app_ui.replace_fonts(&cc.egui_ctx);
-                    Ok(Box::new(tiny_app_ui))
-                }
+                Ok(tiny_app_ui) => Ok(Box::new(tiny_app_ui)),
                 Err(e) => Err(e.into()),
             }
         }),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -69,6 +69,16 @@ impl PresentDataManager {
                 .pause_flag
                 .load(std::sync::atomic::Ordering::Acquire)
             {
+                if is_play_end(
+                    &audio_play_context.live_mode,
+                    &audio_play_context.audio_frame_receiver,
+                    &audio_play_context.video_frame_receiver,
+                    &audio_play_context.demux_eof_flag,
+                ) {
+                    audio_play_context
+                        .pause_flag
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
                 if audio_play_context.audio_player.len() < 8 {
                     let mainstream = {
                         let tiny_decoder = audio_play_context.tiny_decoder.read().await;
@@ -137,7 +147,16 @@ impl PresentDataManager {
                         tiny_decoder.video_time_base,
                     )
                 };
-
+                if is_play_end(
+                    &video_play_context.live_mode,
+                    &video_play_context.audio_frame_receiver,
+                    &video_play_context.video_frame_receiver,
+                    &video_play_context.demux_eof_flag,
+                ) {
+                    video_play_context
+                        .pause_flag
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
                 if PresentDataManager::should_video_chase_audio(
                     main_stream.clone(),
                     audio_time_base,
@@ -336,7 +355,17 @@ impl Drop for PresentDataManager {
         }
     }
 }
-
+fn is_play_end(
+    live_mode: &AtomicBool,
+    audio_frame_receiver: &Receiver<Audio>,
+    video_frame_receiver: &Receiver<Video>,
+    demux_eof_flag: &AtomicBool,
+) -> bool {
+    !live_mode.load(std::sync::atomic::Ordering::Relaxed)
+        && demux_eof_flag.load(std::sync::atomic::Ordering::Relaxed)
+        && audio_frame_receiver.is_empty()
+        && video_frame_receiver.is_empty()
+}
 #[derive(Clone, TypedBuilder)]
 pub struct AudioPlayContext {
     tiny_decoder: Arc<RwLock<TinyDecoder>>,
@@ -348,9 +377,12 @@ pub struct AudioPlayContext {
     pause_flag: Arc<AtomicBool>,
 
     audio_frame_receiver: Receiver<Audio>,
+    video_frame_receiver: Receiver<Video>,
     audio_decode_thread_notify: Arc<Notify>,
     cancellation_token: Arc<CancellationToken>,
     play_tasks_notify: Arc<Notify>,
+    demux_eof_flag: Arc<AtomicBool>,
+    live_mode: Arc<AtomicBool>,
 }
 #[derive(Clone, TypedBuilder)]
 pub struct VideoPlayContext {
@@ -361,10 +393,12 @@ pub struct VideoPlayContext {
     video_texture: Arc<RwLock<Texture>>,
     pause_flag: Arc<AtomicBool>,
     transcoder: Arc<RwLock<Transcoder>>,
-
+    audio_frame_receiver: Receiver<Audio>,
     video_frame_receiver: Receiver<Video>,
 
     video_decode_thread_notify: Arc<Notify>,
     cancellation_token: Arc<CancellationToken>,
     play_tasks_notify: Arc<Notify>,
+    demux_eof_flag: Arc<AtomicBool>,
+    live_mode: Arc<AtomicBool>,
 }


### PR DESCRIPTION
The logic is transfered from timestamp detection
which is not robust to signal with queue empty detection.